### PR TITLE
Add Verifiable Credentials as third authentication option for ITI-YY5

### DIFF
--- a/input/fsh/capabilitystatements.fsh
+++ b/input/fsh/capabilitystatements.fsh
@@ -34,7 +34,7 @@ Usage: #definition
   * documentation = "VHL Sharer provides access to document manifests (List resources) and references (DocumentReference resources) authorized by Verified Health Links (VHLs). Authorization is based on validated VHL tokens containing manifest URLs with folder IDs."
   
   * security
-    * description = "Implementations SHALL support ATNA Authenticate Node [ITI-19] for mutual TLS authentication. VHL-based authorization is required (folder ID in _id parameter), optionally supplemented by OAuth 2.0 or other token-based authentication."
+    * description = "Implementations SHALL support ATNA Authenticate Node [ITI-19] for mutual TLS authentication. VHL-based authorization is required (folder ID in _id parameter), optionally supplemented by HTTP Message Signatures (RFC 9421), OAuth 2.0 with SSRAA, or Verifiable Credentials (W3C VC Data Model 2.0)."
   
   // List Resource
   * resource[0]
@@ -112,7 +112,7 @@ Usage: #definition
   * documentation = "VHL Receiver retrieves document manifests (List resources) and optionally DocumentReference resources from VHL Sharers using VHL-authorized manifest URLs. The client extracts the manifest URL from the VHL payload (obtained via ITI-YY4 Provide VHL) and performs a FHIR search with mandatory parameters."
   
   * security
-    * description = "Implementations SHALL support ATNA Authenticate Node [ITI-19] for mutual TLS authentication. The VHL Receiver SHALL provide the VHL authorization token (folder ID) and MAY provide additional authentication tokens (OAuth 2.0, JWS signatures)."
+    * description = "Implementations SHALL support ATNA Authenticate Node [ITI-19] for mutual TLS authentication. The VHL Receiver SHALL provide the VHL authorization token (folder ID) and MAY provide additional authentication via HTTP Message Signatures (RFC 9421), OAuth 2.0 with SSRAA, or Verifiable Credentials (W3C VC Data Model 2.0)."
   
   // List Resource
   * resource[0]

--- a/input/fsh/usecases.fsh
+++ b/input/fsh/usecases.fsh
@@ -183,4 +183,8 @@ TEFCA's trust model aligns with the VHL profile's trust network architecture. In
 **OAuth with SSRAA Option:**
 
 Organizations already using OAuth with UDAP (via the [HL7 SSRAA IG](http://hl7.org/fhir/us/udap-security/)) can leverage VHL for health record sharing without additional authentication infrastructure. TEFCA participants, for example, can use their existing TEFCA-issued X.509 certificates and UDAP Dynamic Client Registration to authenticate VHL exchanges, enabling seamless interoperability within established national-scale health information networks.
+
+**Verifiable Credentials Option:**
+
+Organizations participating in trust networks that use Decentralized Identifiers (DIDs) and W3C Verifiable Credentials can leverage the Verifiable Credentials Option for decentralized authentication. This is particularly relevant for cross-network federation scenarios where participants from different trust networks need to exchange health records without requiring a centralized authorization server.
 """

--- a/input/images-source/ITI-YY5.plantuml
+++ b/input/images-source/ITI-YY5.plantuml
@@ -7,10 +7,14 @@ participant "VHL Sharer" as Sharer
 
 Receiver -> Sharer: Retrieve Manifest Request [ITI-YY5]
 note right
-  POST signed request with:
+  POST authenticated request with:
   - VHL token
   - Search parameters
   - Passcode (if required)
+  Authentication options:
+  - HTTP Message Signatures (RFC 9421)
+  - OAuth with SSRAA
+  - Verifiable Credentials (W3C VC)
   Over ATNA secure channel (optional)
 end note
 

--- a/input/pagecontent/ITI-YY3.md
+++ b/input/pagecontent/ITI-YY3.md
@@ -131,8 +131,8 @@ The VHL payload SHALL be constructed in alignment with the [SMART Health Links s
    - `flag`: (optional) flags string (e.g., 'P' for passcode, 'L' for long-term, 'U' for direct file access)
    - `label`: (optional) description string (max 80 characters)
    - `v`: version number (defaults to 1)
-   - `extension`: (conditional) object containing implementation-defined extensions. Required when the {{ linkvhls }} supports the OAuth with SSRAA Option, in which case it SHALL include:
-     - `fhirBaseUrl`: the FHIR base URL of the {{ linkvhls }} (e.g., `https://vhl-sharer.example.org`). This enables the {{ linkvhlr }} to perform UDAP Discovery (per Section 2 of the HL7 Security for Scalable Registration, Authentication, and Authorization IG) and Dynamic Client Registration (per Section 3) with the {{ linkvhls }} before making an authenticated manifest request via ITI-YY5.
+   - `extension`: (conditional) object containing implementation-defined extensions. Required when the {{ linkvhls }} supports the OAuth with SSRAA Option or the Verifiable Credentials Option, in which case it SHALL include:
+     - `fhirBaseUrl`: the FHIR base URL of the {{ linkvhls }} (e.g., `https://vhl-sharer.example.org`). For the OAuth with SSRAA Option, this enables the {{ linkvhlr }} to perform UDAP Discovery (per Section 2 of the HL7 Security for Scalable Registration, Authentication, and Authorization IG) and Dynamic Client Registration (per Section 3) with the {{ linkvhls }} before making an authenticated manifest request via ITI-YY5. For the Verifiable Credentials Option, this URL is used to determine the VP proof `domain` value.
 
 5. The JSON Payload is then:
     - Minified
@@ -281,10 +281,11 @@ The VHL Holder MAY:
 - The `_include` parameter SHOULD only be included if the VHL Sharer supports the Include DocumentReference Option
 - This ensures VHL Receivers can successfully retrieve the manifest using ITI-YY5
 
-#### 2:3.YY3.5.5 OAuth with SSRAA Option — FHIR Base URL Extension
-When the {{ linkvhls }} supports the OAuth with SSRAA Option, it SHALL include `extension.fhirBaseUrl` in the SHL payload:
+#### 2:3.YY3.5.5 OAuth with SSRAA Option and Verifiable Credentials Option — FHIR Base URL Extension
+When the {{ linkvhls }} supports the OAuth with SSRAA Option or the Verifiable Credentials Option, it SHALL include `extension.fhirBaseUrl` in the SHL payload:
 - The `fhirBaseUrl` value MUST be the canonical FHIR base URL of the {{ linkvhls }} (e.g., `https://vhl-sharer.example.org`)
-- This URL is used by the {{ linkvhlr }} to perform UDAP Discovery (`{fhirBaseUrl}/.well-known/udap`) and, if not already registered, Dynamic Client Registration with the {{ linkvhls }} before initiating ITI-YY5
+- For OAuth with SSRAA: This URL is used by the {{ linkvhlr }} to perform UDAP Discovery (`{fhirBaseUrl}/.well-known/udap`) and, if not already registered, Dynamic Client Registration with the {{ linkvhls }} before initiating ITI-YY5
+- For Verifiable Credentials: This URL is used by the {{ linkvhlr }} to determine the VP proof `domain` value for request binding in ITI-YY5
 - The `fhirBaseUrl` value is typically derivable from the `url` field (manifest URL) by stripping the path, but including it explicitly avoids ambiguity when the authorization server is hosted separately
-- The {{ linkvhlr }} SHOULD cache its UDAP registration per `fhirBaseUrl` to avoid re-registering on every VHL scan
-- The `fhirBaseUrl` field MUST NOT be present if the {{ linkvhls }} does not support the OAuth with SSRAA Option, to avoid misleading {{ linkvhlr }}s into attempting UDAP Discovery unnecessarily
+- The {{ linkvhlr }} SHOULD cache its UDAP registration per `fhirBaseUrl` to avoid re-registering on every VHL scan (OAuth with SSRAA Option)
+- The `fhirBaseUrl` field MUST NOT be present if the {{ linkvhls }} does not support the OAuth with SSRAA Option or the Verifiable Credentials Option, to avoid misleading {{ linkvhlr }}s into attempting discovery unnecessarily

--- a/input/pagecontent/ITI-YY5.md
+++ b/input/pagecontent/ITI-YY5.md
@@ -16,9 +16,11 @@ This transaction occurs after the {{ linkvhlr }} has received a VHL from a VHL H
 
 **FHIR Search Transaction:** This transaction uses a standard FHIR search on the List resource, following the same pattern as MHD ITI-66 Find Document Lists. The manifest URL from the VHL payload contains all necessary FHIR search parameters. No custom operation is required.
 
-**Authentication:** Implementations SHALL support at least one of the following authentication mechanisms. Participants MAY use **HTTP Message Signatures (RFC 9421)** or **OAuth with SSRAA** depending on their deployment context. The VHL Sharer authenticates the requesting VHL Receiver before processing the request.
+**Authentication:** Implementations SHALL support at least one of the following authentication mechanisms. Participants MAY use **HTTP Message Signatures (RFC 9421)**, **OAuth with SSRAA**, or **Verifiable Credentials (W3C VC Data Model 2.0)** depending on their deployment context. All three options are equal alternatives; none is mandatory. The VHL Sharer authenticates the requesting VHL Receiver before processing the request.
 
 **OAuth with SSRAA Option:** Implementations MAY support the **OAuth with SSRAA Option**, which uses OAuth 2.0 tokens for authentication as defined in the [HL7 Security for Scalable Registration, Authentication, and Authorization IG](http://hl7.org/fhir/us/udap-security/) (SSRAA). When this option is supported, implementations use OAuth Backend Services with JWT client assertions for system-to-system authentication.
+
+**Verifiable Credentials Option:** Implementations MAY support the **Verifiable Credentials Option**, which uses [W3C Verifiable Credentials Data Model 2.0](https://www.w3.org/TR/vc-data-model-2.0/) for authentication. When this option is supported, the {{ linkvhlr }} presents a Verifiable Presentation (VP) containing a Verifiable Credential (VC) issued by the Trust Anchor, with a challenge derived from the request body to bind the presentation to the specific request.
 
 **Include DocumentReference Option:** A {{ linkvhls }} that supports the **Include DocumentReference Option** SHALL process the `_include=List:item` parameter to retrieve both the List and the referenced DocumentReference resources in a single response. This optimization reduces the number of round trips required by the {{ linkvhlr }}. If a {{ linkvhls }} does not support this option, it SHALL ignore the `_include` parameter, and the {{ linkvhlr }} SHALL retrieve each DocumentReference individually using separate read requests.
 
@@ -63,6 +65,11 @@ Both the {{ linkvhlr }} and {{ linkvhls }} SHALL authenticate each other's parti
 - **SMART App Launch Backend Services**: [Backend Services](http://hl7.org/fhir/smart-app-launch/backend-services.html)
 - **HL7 Security for Scalable Registration, Authentication, and Authorization IG**: [SSRAA](http://hl7.org/fhir/us/udap-security/)
 - **ITI Internet User Authorization (IUA)**: [IUA Profile](https://profiles.ihe.net/ITI/IUA/)
+
+**Verifiable Credentials (Optional):**
+- **W3C VC Data Model 2.0**: [Verifiable Credentials Data Model v2.0](https://www.w3.org/TR/vc-data-model-2.0/) - for Verifiable Credentials Option
+- **W3C DID Core 1.0**: [Decentralized Identifiers (DIDs) v1.0](https://www.w3.org/TR/did-core/) - DID-based identity for VC holder and issuer
+- **JsonWebSignature2020**: [JSON Web Signature 2020](https://w3id.org/security/suites/jws-2020/v1) - proof suite for VC and VP signatures
 
 **SHL Specifications:**
 - **SHL Manifest Request**: [SHL Manifest Request](http://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html#smart-health-link-manifest-request)
@@ -313,7 +320,135 @@ _id=abc123def456&code=folder&status=current&patient.identifier=urn%3Aoid%3A2.16.
 - Token lifetime SHOULD be limited (recommended: 1 hour maximum)
 - Authorization server MUST validate the JWT signature and the associated certificate validity, including that the certificate chains to a trust anchor in the trust community
 
-##### 2:3.YY5.4.1.5 Expected Actions - VHL Receiver
+##### 2:3.YY5.4.1.5 Authentication Option - Verifiable Credentials
+
+Implementations MAY authenticate using **Verifiable Credentials** per the [W3C Verifiable Credentials Data Model 2.0](https://www.w3.org/TR/vc-data-model-2.0/). This option is not required; participants MAY instead use HTTP Message Signatures (see Section 2:3.YY5.4.1.3) or OAuth with SSRAA (see Section 2:3.YY5.4.1.4). Verifiable Credentials provide decentralized, attribute-rich authentication with cryptographic request binding via Verifiable Presentations.
+
+**Preconditions: Verifiable Credential Issuance**
+
+Before a Verifiable Credential can be presented, the {{ linkvhlr }} MUST obtain a **VHLParticipantCredential** from the Trust Anchor or a recognized issuer in the trust network. This credential is issued when the {{ linkvhlr }} registers its PKI material via ITI-YY1 (Submit PKI Material with DID). The credential MAY be long-lived and reused across multiple requests.
+
+**Verifiable Credential Structure:**
+
+The VC issued to the {{ linkvhlr }} SHALL conform to the W3C VC Data Model 2.0 and use the JsonWebSignature2020 proof suite, consistent with the proof structure defined in ITI-YY2:
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "type": ["VerifiableCredential", "VHLParticipantCredential"],
+  "issuer": "did:web:trust-anchor.example.org",
+  "validFrom": "2025-01-15T00:00:00Z",
+  "validUntil": "2026-01-15T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:vhl-receiver.example.org",
+    "organizationName": "General Hospital",
+    "role": "VHLReceiver",
+    "trustNetwork": "example-trust-network"
+  },
+  "proof": {
+    "type": "JsonWebSignature2020",
+    "created": "2025-01-15T12:00:00Z",
+    "verificationMethod": "did:web:trust-anchor.example.org#signing-key-1",
+    "proofPurpose": "assertionMethod",
+    "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vc_signature_value"
+  }
+}
+```
+
+**Verifiable Presentation Structure (Request Binding):**
+
+To bind the credential presentation to the specific HTTP request, the {{ linkvhlr }} SHALL construct a Verifiable Presentation (VP) with a `challenge` derived from the request body. This ensures that the VP cannot be replayed for a different request.
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "type": ["VerifiablePresentation"],
+  "holder": "did:web:vhl-receiver.example.org",
+  "verifiableCredential": [
+    { "...VC as above..." }
+  ],
+  "proof": {
+    "type": "JsonWebSignature2020",
+    "created": "2025-06-15T10:30:00Z",
+    "verificationMethod": "did:web:vhl-receiver.example.org#key-1",
+    "proofPurpose": "authentication",
+    "challenge": "X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=",
+    "domain": "vhl-sharer.example.org",
+    "jws": "eyJhbGciOiJFUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..vp_signature_value"
+  }
+}
+```
+
+**Request Structure:**
+
+```http
+POST /List/_search HTTP/1.1
+Host: vhl-sharer.example.org
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 234
+Content-Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
+VP: eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIi...
+Accept: application/fhir+json
+
+_id=abc123def456&code=folder&status=current&patient.identifier=urn%3Aoid%3A2.16.840.1.113883.2.4.6.3%7CPASSPORT123&_include=List%3Aitem&recipient=Dr.+Smith+Hospital&passcode=user-pin&embeddedLengthMax=10000
+```
+
+**VP Header Components:**
+
+1. **Content-Digest Header:**
+   - SHA-256 hash of the request body (same as HTTP Message Signatures)
+   - Format: `sha-256=<base64-encoded-hash>`
+   - MUST be included for POST requests with body
+
+2. **VP Header:**
+   - Base64url-encoded Verifiable Presentation JSON
+   - Contains the VC and the VP proof with challenge and domain
+   - The `challenge` in the VP proof SHALL be the base64-encoded SHA-256 hash value from the Content-Digest header (binding the VP to the request body)
+   - The `domain` in the VP proof SHALL be the `@authority` of the request (the VHL Sharer's hostname)
+
+**Signing Process:**
+
+1. {{ linkvhlr }} constructs request body with FHIR search parameters and SHL parameters
+2. {{ linkvhlr }} computes Content-Digest (SHA-256 of body)
+3. {{ linkvhlr }} constructs VP containing the VHLParticipantCredential
+4. {{ linkvhlr }} sets VP proof `challenge` to the Content-Digest hash value
+5. {{ linkvhlr }} sets VP proof `domain` to the VHL Sharer's authority
+6. {{ linkvhlr }} signs VP using their private key (corresponding to the DID in the trust list)
+7. {{ linkvhlr }} base64url-encodes the VP and includes it as the `VP` header
+8. {{ linkvhlr }} includes Content-Digest header in request
+
+**Verification Process:**
+
+1. {{ linkvhls }} extracts `VP` header and base64url-decodes it
+2. {{ linkvhls }} extracts the VC from the VP's `verifiableCredential` array
+3. {{ linkvhls }} verifies VC issuer is in the trust list (ITI-YY2)
+4. {{ linkvhls }} verifies VC proof signature using the issuer's public key from the trust list
+5. {{ linkvhls }} verifies VC is not expired (`validFrom` / `validUntil`)
+6. {{ linkvhls }} verifies VC `credentialSubject.id` matches the VP `holder`
+7. {{ linkvhls }} verifies VP proof signature using the holder's public key from the trust list
+8. {{ linkvhls }} verifies VP proof `challenge` matches the Content-Digest header value
+9. {{ linkvhls }} verifies VP proof `domain` matches the server's authority
+10. {{ linkvhls }} verifies VP proof `created` timestamp is within acceptable range (±2 minutes recommended)
+11. If valid, {{ linkvhls }} processes request and returns Bundle
+12. If invalid, {{ linkvhls }} returns 401 Unauthorized
+
+**Security Considerations for Verifiable Credentials:**
+
+- Private keys MUST be stored securely (Hardware Security Module recommended)
+- Public keys for VC issuers and VP holders MUST be obtained from trust list (ITI-YY2)
+- The VP `challenge` MUST match the Content-Digest to bind the presentation to the request body
+- The VP `domain` MUST match the server authority to prevent cross-domain replay
+- VP proof `created` timestamp MUST be validated for freshness (±2 minutes recommended)
+- VCs SHOULD be checked for revocation if the trust network maintains a revocation list
+- The VC issuer MUST be a Trust Anchor or recognized issuer in the trust network
+
+##### 2:3.YY5.4.1.6 Expected Actions - VHL Receiver
 
 The {{ linkvhlr }} SHALL:
 
@@ -330,7 +465,7 @@ The {{ linkvhlr }} SHALL:
      - embeddedLengthMax (optional) - size hint for embedded content
    - Encode parameters as `application/x-www-form-urlencoded`
 
-3. **Authenticate Request** (use one of the following options; neither is required):
+3. **Authenticate Request** (use one of the following options; none is mandatory):
    - **Option A - HTTP Message Signatures** (if supported):
      - Compute Content-Digest (SHA-256 of request body)
      - Construct signature base from HTTP components
@@ -340,6 +475,12 @@ The {{ linkvhlr }} SHALL:
      - Obtain access token using JWT client assertion
      - Include token in Authorization header
      - Reuse token for subsequent requests until expiration
+   - **Option C - Verifiable Credentials** (if supported):
+     - Compute Content-Digest (SHA-256 of request body)
+     - Construct VP containing VHLParticipantCredential with challenge set to Content-Digest hash value
+     - Sign VP using receiver's private key
+     - Base64url-encode VP and include as VP header
+     - Include Content-Digest header
 
 4. **Send Request**:
    - POST to `/List/_search` endpoint at VHL Sharer's base URL
@@ -358,17 +499,18 @@ The {{ linkvhlr }} SHALL:
 
 The {{ linkvhlr }} MAY:
 - Cache OAuth access tokens for reuse (OAuth with SSRAA Option)
+- Cache Verifiable Credentials for reuse until expiration (Verifiable Credentials Option)
 - Implement retry logic for transient failures
-- Support both HTTP Message Signatures and OAuth with SSRAA Option
+- Support any combination of HTTP Message Signatures, OAuth with SSRAA, and Verifiable Credentials options
 
-##### 2:3.YY5.4.1.6 Expected Actions - VHL Sharer
+##### 2:3.YY5.4.1.7 Expected Actions - VHL Sharer
 
 Upon receiving Retrieve Manifest Request, the {{ linkvhls }} SHALL:
 
 1. **Parse Request**:
    - Extract FHIR search parameters from request body
    - Extract SHL parameters (recipient, passcode, embeddedLengthMax)
-   - Identify authentication method used (HTTP signatures or OAuth token)
+   - Identify authentication method used (HTTP signatures, OAuth token, or Verifiable Credentials)
 
 2. **Authenticate Receiver**:
    - **HTTP Message Signatures**:
@@ -385,6 +527,17 @@ Upon receiving Retrieve Manifest Request, the {{ linkvhls }} SHALL:
      - Verify token expiration
      - Verify token scope authorizes access to the VHL
      - Reject if token invalid or expired (401 Unauthorized)
+   - **Verifiable Credentials Option**:
+     - Extract and base64url-decode VP from `VP` header
+     - Verify VC issuer is in the trust list (ITI-YY2)
+     - Verify VC proof signature using issuer's public key
+     - Verify VC validity period (`validFrom` / `validUntil`)
+     - Verify VC `credentialSubject.id` matches VP `holder`
+     - Verify VP proof signature using holder's public key from trust list
+     - Verify VP proof `challenge` matches Content-Digest header value
+     - Verify VP proof `domain` matches server authority
+     - Verify VP proof `created` timestamp is within acceptable range (±2 minutes)
+     - Reject if any verification fails (401 Unauthorized)
 
 3. **Authorize Request**:
    - Validate folder ID (_id parameter) corresponds to valid VHL
@@ -650,8 +803,8 @@ The {{ linkvhlr }} MAY:
 
 Secure transport is required for all communications in this transaction. Implementations SHALL comply with the **IHE ATNA Profile** (ITI TF-1: Section 9) for transport security requirements
 
-#### 2:3.YY5.5.2 HTTP Message Signatures 
-All implementations SHALL support HTTP Message Signatures per RFC 9421:
+#### 2:3.YY5.5.2 HTTP Message Signatures
+Implementations that support the Sign Manifest Request Option SHALL comply with HTTP Message Signatures per RFC 9421:
 - Signature MUST include `@method`, `@path`, `@authority`, `content-type`, `content-digest`
 - Content-Digest MUST be SHA-256 or stronger
 - Signature algorithm: ECDSA P-256 SHA-256 (recommended) or RSA 2048+ with PSS or PKCS#1 v1.5
@@ -661,7 +814,7 @@ All implementations SHALL support HTTP Message Signatures per RFC 9421:
 - Timestamp validation MUST enforce freshness (±2 minutes recommended)
 - Replay attacks prevented by timestamp validation
 
-#### 2:3.YY5.5.3 OAuth with SSRAA Option 
+#### 2:3.YY5.5.3 OAuth with SSRAA Option
 Implementations that support OAuth with SSRAA Option SHALL:
 - Use OAuth 2.0 Backend Services (client_credentials grant)
 - Use JWT client assertions (private_key_jwt) for client authentication
@@ -671,7 +824,21 @@ Implementations that support OAuth with SSRAA Option SHALL:
 - Check JWT `jti` claim to prevent replay attacks
 - Obtain receiver's public key from trust list for JWT signature validation
 
-#### 2:3.YY5.5.4 VHL Authorization
+#### 2:3.YY5.5.4 Verifiable Credentials Option
+Implementations that support the Verifiable Credentials Option SHALL:
+- Use W3C Verifiable Credentials Data Model 2.0 with JsonWebSignature2020 proof suite
+- Present credentials via a Verifiable Presentation (VP) with `challenge` and `domain`
+- Set VP `challenge` to the Content-Digest hash value to bind the presentation to the request body
+- Set VP `domain` to the VHL Sharer's authority to prevent cross-domain replay
+- Verify VC issuer is a Trust Anchor or recognized issuer in the trust network
+- Verify VC validity period (`validFrom` / `validUntil`)
+- Verify VP proof signature using the holder's public key from the trust list
+- Validate VP proof `created` timestamp for freshness (±2 minutes recommended)
+- Check VC revocation status if the trust network maintains a revocation list
+- Store private keys securely (Hardware Security Module recommended)
+- Obtain public keys from trust list (ITI-YY2) for signature verification
+
+#### 2:3.YY5.5.5 VHL Authorization
 {{ linkvhls }} MUST validate VHL before returning documents:
 - Verify folder ID (_id parameter) corresponds to valid VHL
 - Validate VHL signature (HCERT/CWT COSE signature from ITI-YY3)
@@ -682,33 +849,33 @@ Implementations that support OAuth with SSRAA Option SHALL:
   - Use strong hash function (bcrypt, Argon2, PBKDF2)
 - Confirm VHL scope authorizes requested documents
 
-#### 2:3.YY5.5.5 Trust Network Validation
+#### 2:3.YY5.5.6 Trust Network Validation
 Both {{ linkvhlr }} and {{ linkvhls }} SHALL:
 - Authenticate each other's participation in trust network
 - Obtain public keys from trust list (ITI-YY2 Retrieve Trust List with DID)
 - Validate certificates are not expired or revoked
-- Use `keyid` (HTTP signatures) or the client key (OAuth JWT) to identify the client's key
+- Use `keyid` (HTTP signatures), the client key (OAuth JWT), or the holder DID (Verifiable Credentials) to identify the client's key
 - Reject requests from participants not in trust list (401 Unauthorized)
 
-#### 2:3.YY5.5.6 Audit Logging
+#### 2:3.YY5.5.7 Audit Logging
 Both {{ linkvhlr }} and {{ linkvhls }} SHOULD log:
 - All document access requests (successful and failed)
-- Authentication method used (HTTP signatures or OAuth)
-- Receiver identity (from keyid or OAuth token)
+- Authentication method used (HTTP signatures, OAuth, or Verifiable Credentials)
+- Receiver identity (from keyid, OAuth token, or VC holder DID)
 - VHL folder ID
 - Authorization decisions (approved/denied)
 - Timestamps
 - IP addresses
 - User identifiers (from recipient parameter)
 
-#### 2:3.YY5.5.7 Rate Limiting
+#### 2:3.YY5.5.8 Rate Limiting
 {{ linkvhls }} SHOULD implement rate limiting:
-- Per receiver (identified by keyid or OAuth client_id)
+- Per receiver (identified by keyid, OAuth client_id, or VC holder DID)
 - Per folder ID (to prevent brute force on VHL tokens)
 - Per IP address
 - Return 429 Too Many Requests when limits exceeded
 
-#### 2:3.YY5.5.8 Passcode Security
+#### 2:3.YY5.5.9 Passcode Security
 When VHL is passcode-protected (P flag):
 - Passcode MUST be validated using constant-time comparison
 - Failed passcode attempts SHOULD be rate limited

--- a/input/pagecontent/testplan.md
+++ b/input/pagecontent/testplan.md
@@ -33,15 +33,16 @@ The VHL Receiver must be tested for its ability to correctly perform the full VH
 
 #### Manifest Retrieval
 
-The VHL Receiver and VHL Sharer must be tested for the Retrieve Manifest transaction [ITI-YY5]. This includes the VHL Receiver's ability to construct and send a valid FHIR search request on the List resource with appropriate search parameters (_id, code, status, patient.identifier, _include) and SHL parameters (recipient, passcode). The VHL Sharer must be tested for returning a conformant searchset Bundle. Authentication via HTTP Message Signatures (RFC 9421) is required and must be validated.
+The VHL Receiver and VHL Sharer must be tested for the Retrieve Manifest transaction [ITI-YY5]. This includes the VHL Receiver's ability to construct and send a valid FHIR search request on the List resource with appropriate search parameters (_id, code, status, patient.identifier, _include) and SHL parameters (recipient, passcode). The VHL Sharer must be tested for returning a conformant searchset Bundle. Authentication via one of the supported options (HTTP Message Signatures, OAuth with SSRAA, or Verifiable Credentials) must be validated.
 
 #### Options Testing
 
 Testing of actor options includes:
-- **Sign Manifest Request Option** - VHL Receiver digitally signs manifest requests; VHL Sharer verifies the signature for mutual authentication and non-repudiation.
+- **Sign Manifest Request Option** - VHL Receiver digitally signs manifest requests using HTTP Message Signatures (RFC 9421); VHL Sharer verifies the signature for mutual authentication and non-repudiation.
 - **Include DocumentReference Option** - VHL Receiver requests and VHL Sharer returns DocumentReference resources in the manifest response using `_include=List:item`.
 - **Verify Document Signature Option** - VHL Receiver verifies digital signatures on retrieved documents using previously obtained PKI material.
-- **OAuth with FAST Option** - VHL Receiver and VHL Sharer use OAuth 2.0 access tokens as an alternative authentication mechanism for ITI-YY5.
+- **OAuth with SSRAA Option** - VHL Receiver and VHL Sharer use OAuth 2.0 access tokens as an alternative authentication mechanism for ITI-YY5.
+- **Verifiable Credentials Option** - VHL Receiver and VHL Sharer use W3C Verifiable Credentials with Verifiable Presentations for decentralized, attribute-rich authentication with cryptographic request binding for ITI-YY5.
 
 
 

--- a/input/pagecontent/volume-1.md
+++ b/input/pagecontent/volume-1.md
@@ -243,9 +243,11 @@ Options that may be selected for each actor in this implementation guide are lis
 | ^              | Include DocumentReference            |
 | ^              | Verify Document Signature            |
 | ^              | OAuth with SSRAA                     |
+| ^              | Verifiable Credentials               |
 | {{ linkvhls }} | Include DocumentReference            |
 | ^              | Sign Manifest Request                |
 | ^              | OAuth with SSRAA                     |
+| ^              | Verifiable Credentials               |
 {: .grid}
 
 
@@ -293,6 +295,20 @@ The OAuth with SSRAA Option enables the {{ linkvhlr }} and {{ linkvhls }} to use
 **Complementary Option:** Both the {{ linkvhlr }} and {{ linkvhls }} must support this option for OAuth-based authentication to be used. If only one actor supports this option, HTTP Message Signatures or other authentication mechanisms defined in ITI-YY5 SHALL be used instead.
 
 See ITI-YY5 Section 2:3.YY5.4.1.4 for detailed OAuth flow and examples.
+
+### XX.2.5 Verifiable Credentials Option
+
+The Verifiable Credentials Option enables the {{ linkvhlr }} and {{ linkvhls }} to use [W3C Verifiable Credentials Data Model 2.0](https://www.w3.org/TR/vc-data-model-2.0/) for authentication during the ITI-YY5 Retrieve Manifest transaction, as an alternative to HTTP Message Signatures or OAuth with SSRAA. This option leverages the existing DID-based trust infrastructure (ITI-YY1, ITI-YY2) and the JsonWebSignature2020 proof suite already used in trust list proofs.
+
+This option provides:
+- Decentralized, attribute-rich authentication using W3C standards
+- Cryptographic request binding via Verifiable Presentations with challenge-response
+- Non-repudiation of manifest requests
+- Natural alignment with the VHL profile's DID and VC-based trust model
+
+**Complementary Option:** Both the {{ linkvhlr }} and {{ linkvhls }} must support this option for VC-based authentication to be used. If only one actor supports this option, HTTP Message Signatures or OAuth with SSRAA SHALL be used instead.
+
+See ITI-YY5 Section 2:3.YY5.4.1.5 for detailed Verifiable Credentials flow and examples.
 
 <a name="required-groupings"> </a>
 

--- a/input/tests/features/ITI-YY3-generate-vhl-responder.feature
+++ b/input/tests/features/ITI-YY3-generate-vhl-responder.feature
@@ -80,17 +80,17 @@ Feature: ITI-YY3 Generate VHL – VHL Sharer Expected Actions
     When the "v" field is set in the SHL payload
     Then the "v" field SHALL default to 1
 
-  # ─── OAuth with SSRAA Option ───────────────────────────────────────────────
+  # ─── OAuth with SSRAA Option / Verifiable Credentials Option ────────────────
 
   @responder-actions @SHALL
-  Scenario: VHL Sharer includes extension.fhirBaseUrl when OAuth with SSRAA Option is supported
-    Given the VHL Sharer supports the OAuth with SSRAA Option
+  Scenario: VHL Sharer includes extension.fhirBaseUrl when OAuth with SSRAA Option or Verifiable Credentials Option is supported
+    Given the VHL Sharer supports the OAuth with SSRAA Option or the Verifiable Credentials Option
     When the SHL payload is constructed
     Then the "extension" object SHALL include "fhirBaseUrl" set to the canonical FHIR base URL of the VHL Sharer
 
   @responder-actions @MUST
-  Scenario: VHL Sharer does not include extension.fhirBaseUrl when OAuth with SSRAA Option is not supported
-    Given the VHL Sharer does NOT support the OAuth with SSRAA Option
+  Scenario: VHL Sharer does not include extension.fhirBaseUrl when neither OAuth with SSRAA Option nor Verifiable Credentials Option is supported
+    Given the VHL Sharer does NOT support the OAuth with SSRAA Option or the Verifiable Credentials Option
     When the SHL payload is constructed
     Then the "extension.fhirBaseUrl" field MUST NOT be present
 

--- a/input/tests/features/ITI-YY5-retrieve-manifest-initiator.feature
+++ b/input/tests/features/ITI-YY5-retrieve-manifest-initiator.feature
@@ -104,6 +104,50 @@ Feature: ITI-YY5 Retrieve Manifest – VHL Receiver Expected Actions
     When subsequent Retrieve Manifest requests are needed within that lifetime
     Then the VHL Receiver MAY reuse the access token until its "exp" claim is reached
 
+  # ─── Authentication: Verifiable Credentials (Option C) ─────────────────────
+
+  @initiator-actions @MAY
+  Scenario: VHL Receiver may authenticate using Verifiable Credentials per W3C VC Data Model 2.0
+    Given the VHL Receiver supports the Verifiable Credentials Option
+    When the request is assembled
+    Then the request MAY include Content-Digest and VP headers per W3C VC Data Model 2.0
+
+  @initiator-actions @SHALL
+  Scenario: VP challenge is derived from the Content-Digest when Verifiable Credentials are used
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the VP proof is constructed
+    Then the "challenge" SHALL be the base64-encoded SHA-256 hash value from the Content-Digest header
+
+  @initiator-actions @SHALL
+  Scenario: VP domain matches the VHL Sharer's authority when Verifiable Credentials are used
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the VP proof is constructed
+    Then the "domain" SHALL equal the VHL Sharer's authority from the manifest URL
+
+  @initiator-actions @SHALL
+  Scenario: VC is issued by a Trust Anchor or recognized issuer in the trust network
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the VP verifiableCredential is inspected
+    Then the VC issuer SHALL be a Trust Anchor or recognized issuer obtained via ITI-YY2
+
+  @initiator-actions @SHALL
+  Scenario: VP proof is signed with the receiver's private key corresponding to its DID
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the VP proof is constructed
+    Then the VP SHALL be signed using the receiver's private key corresponding to its DID in the trust list
+
+  @initiator-actions @SHALL
+  Scenario: VP proof created timestamp is set to the current time when Verifiable Credentials are used
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the VP proof "created" field is set
+    Then the value SHALL be the current ISO 8601 datetime at time of signing
+
+  @initiator-actions @MAY
+  Scenario: VHL Receiver may cache Verifiable Credentials for reuse until expiration
+    Given the VHL Receiver has obtained a VHLParticipantCredential with a validity period
+    When subsequent Retrieve Manifest requests are needed within that period
+    Then the VHL Receiver MAY reuse the VC until its "validUntil" datetime is reached
+
   # ─── §2:3.YY5.5.5 Trust Network Validation ────────────────────────────────
 
   @security @SHALL

--- a/input/tests/features/ITI-YY5-retrieve-manifest-message.feature
+++ b/input/tests/features/ITI-YY5-retrieve-manifest-message.feature
@@ -1,8 +1,9 @@
 Feature: ITI-YY5 Retrieve Manifest – Message Semantics
   Defines the format of the ITI-YY5 request and response messages.
   The request is an HTTP POST to /List/_search with FHIR search parameters
-  and SHL parameters. Authentication is via HTTP Message Signatures (RFC 9421)
-  or OAuth with SSRAA Option. The response is a FHIR searchset Bundle.
+  and SHL parameters. Authentication is via HTTP Message Signatures (RFC 9421),
+  OAuth with SSRAA Option, or Verifiable Credentials (W3C VC Data Model 2.0).
+  All three are equal alternatives; none is mandatory. The response is a FHIR searchset Bundle.
   Defined once here for both the VHL Receiver (initiator) and VHL Sharer (responder).
 
   Background:
@@ -127,6 +128,40 @@ Feature: ITI-YY5 Retrieve Manifest – Message Semantics
     Given the VHL Receiver is authenticating using OAuth with SSRAA Option
     When the authorization header is set
     Then the request SHALL include "Authorization: Bearer <access-token>"
+
+  # ─── Request: Verifiable Credentials Headers (when Option C is used) ────────
+
+  @message-semantics @SHALL
+  Scenario: Request includes Content-Digest header with SHA-256 hash of the body when Verifiable Credentials are used
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the Content-Digest header is computed
+    Then it SHALL be present in the format "Content-Digest: sha-256=<base64-encoded-hash>"
+    And the hash SHALL be the SHA-256 digest of the raw request body bytes
+
+  @message-semantics @SHALL
+  Scenario: Request includes a VP header with a base64url-encoded Verifiable Presentation when Verifiable Credentials are used
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the VP header is constructed
+    Then the request SHALL include a "VP" header containing a base64url-encoded Verifiable Presentation
+
+  @message-semantics @SHALL
+  Scenario: VP proof challenge matches the Content-Digest hash value
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the VP proof is constructed
+    Then the "challenge" field SHALL equal the base64-encoded SHA-256 hash value from the Content-Digest header
+
+  @message-semantics @SHALL
+  Scenario: VP proof domain matches the VHL Sharer authority
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the VP proof is constructed
+    Then the "domain" field SHALL equal the VHL Sharer's authority (hostname)
+
+  @message-semantics @SHALL
+  Scenario: VP contains a VHLParticipantCredential issued by a trusted issuer
+    Given the VHL Receiver is authenticating using Verifiable Credentials
+    When the VP verifiableCredential array is inspected
+    Then it SHALL contain a VC with type including "VHLParticipantCredential"
+    And the VC issuer SHALL be a Trust Anchor or recognized issuer in the trust network
 
   # ─── Response: Success Structure ─────────────────────────────────────────────
 

--- a/input/tests/features/ITI-YY5-retrieve-manifest-responder.feature
+++ b/input/tests/features/ITI-YY5-retrieve-manifest-responder.feature
@@ -93,6 +93,68 @@ Feature: ITI-YY5 Retrieve Manifest – VHL Sharer Expected Actions
     When the "jti" claim is evaluated
     Then the authorization server SHOULD check the "jti" claim to prevent replay attacks
 
+  # ─── Verifiable Credentials Verification (Option C) ───────────────────────
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer extracts and decodes the VP from the VP header when Verifiable Credentials are used
+    Given the request includes a "VP" header and the Verifiable Credentials Option is supported
+    When the VHL Sharer processes the authentication headers
+    Then the VHL Sharer SHALL base64url-decode the VP header and parse the Verifiable Presentation
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer verifies the VC issuer is in the trust list
+    Given the VP has been extracted
+    When the VC issuer is checked
+    Then the VHL Sharer SHALL verify the VC issuer is a Trust Anchor or recognized issuer in the trust list (ITI-YY2)
+    And SHALL return HTTP 401 Unauthorized if the issuer is not recognized
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer verifies the VC proof signature using the issuer's public key
+    Given the VC issuer has been validated
+    When the VC proof is verified
+    Then the VHL Sharer SHALL verify the VC proof signature using the issuer's public key from the trust list
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer verifies the VC is within its validity period
+    Given the VC has been extracted from the VP
+    When the VC validity period is checked
+    Then the VHL Sharer SHALL verify the current time is between "validFrom" and "validUntil"
+    And SHALL return HTTP 401 Unauthorized if the VC is expired or not yet valid
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer verifies the VP proof signature using the holder's public key
+    Given the VC credentialSubject.id matches the VP holder
+    When the VP proof is verified
+    Then the VHL Sharer SHALL verify the VP proof signature using the holder's public key from the trust list
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer verifies the VP challenge matches the Content-Digest
+    Given the VP proof has been extracted
+    When the challenge is validated
+    Then the VHL Sharer SHALL verify the VP proof "challenge" matches the Content-Digest header value
+    And SHALL return HTTP 401 Unauthorized if they do not match
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer verifies the VP domain matches the server authority
+    Given the VP proof has been extracted
+    When the domain is validated
+    Then the VHL Sharer SHALL verify the VP proof "domain" matches the server's authority
+    And SHALL return HTTP 401 Unauthorized if they do not match
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer enforces VP proof timestamp freshness when Verifiable Credentials are used
+    Given the VP proof "created" timestamp is more than the acceptable range in the past
+    When the timestamp is validated
+    Then the VHL Sharer SHALL reject the request as a potential replay
+    And the response SHALL be HTTP 401 Unauthorized
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer returns HTTP 401 for a request with an invalid Verifiable Presentation
+    Given the request carries a "VP" header that fails verification
+    When VP verification is performed
+    Then the VHL Sharer SHALL return HTTP 401 Unauthorized
+    And the response SHALL include a FHIR OperationOutcome with issue.code "security"
+
   # ─── §2:3.YY5.5.5 Trust Network Validation ────────────────────────────────
 
   @security @SHALL


### PR DESCRIPTION
Add W3C Verifiable Credentials (VC Data Model 2.0) as an equal alternative to HTTP Message Signatures and OAuth with SSRAA for the Retrieve Manifest transaction. All three options are now optional alternatives; none is baseline mandatory.

Key changes:
- New ITI-YY5 section 2:3.YY5.4.1.5 defining VC authentication with Verifiable Presentations using challenge-response for request binding
- Fix SHALL/MAY normative inconsistency in security considerations
- Fix "OAuth with FAST" typo to "OAuth with SSRAA" in testplan
- Update actor options table, capability statements, test plan, feature files, PlantUML diagram, and TEFCA use case
- Extend fhirBaseUrl SHL payload extension to cover VC option

<!-- 
Thanks for creating this pull request 

Please make sure that the pull request is limited to one Issue and keep it as small as possible. You can open multiple pull request instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] I have selected a committee co-chair to review the PR

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->