### PR TITLE
Add Verifiable Credential Option to ITI-YY5 (and ITI-YY3)

### DIFF
--- a/input/fsh/usecases.fsh
+++ b/input/fsh/usecases.fsh
@@ -21,6 +21,10 @@ Trust in the GDHCN is established through a Public Key Infrastructure (PKI). Eac
 
 The GDHCN distributes trust lists using [Decentralized Identifiers (DIDs)](https://www.w3.org/TR/did-core/). Each participating jurisdiction's key material is represented as a DID Document containing verification methods with the jurisdiction's public keys. These DID Documents are published as endpoints by the Trust Anchor, analogous to how the [IHE mCSD Profile](https://profiles.ihe.net/ITI/mCSD/) distributes service endpoints for Organizations. This enables participants to discover and retrieve the PKI material needed for signature verification through a standardized, cacheable, and federated mechanism.
 
+**Verifiable Credential Option:**
+
+Because GDHCN participants are already registered in the trust network with DID Documents, they are well-positioned to use the Verifiable Credential Option for ITI-YY5 Retrieve Manifest authentication. A VHL Receiver acting within the GDHCN can self-issue a JWT-encoded Verifiable Credential (`application/vc+jwt`) using its registered DID and present it to the VHL Sharer via `Authorization: JWT-VC <token>`, without requiring any additional authorization server infrastructure.
+
 **Trust Network Gateway:**
 
 The GDHCN Trust Network Gateway (TNG) provides a federated architecture that enables multiple trust anchors and cross-gateway trust propagation. The TNG supports both an API gateway method and DID-based resolution for trust list distribution, ensuring interoperability across diverse jurisdictional implementations.
@@ -68,7 +72,7 @@ Key Features:
 
 Some of the challenges faced during the pilot implementation, though not necessarily to be taken up in this profile, include:
 
-- while not the main point of security, leveraging the PIN is a weakness, need to enable better options for future consideration (e.g. biometrics, other authorization methods)
+- while not the main point of security, leveraging the PIN is a weakness, need to enable better options for future consideration (e.g. biometrics, other authorization methods). The Verifiable Credential Option for ITI-YY5 provides one such improvement: KSA healthcare system VHL Receivers can self-issue a JWT-encoded VC using their DID registered in the GDHCN trust network, presenting it to the VHL Sharer without requiring a PIN or separate authorization server.
 - in planning for expansion to umrah and general tourism, there will not in general be a health check which presents some process challenges such as not having a encounter point to record consent prior to a visit
 - how to scale and automate some of the health checks (e.g. are vaccinations sufficient) using verifiable health documents (e.g. the IPS).
 
@@ -183,4 +187,8 @@ TEFCA's trust model aligns with the VHL profile's trust network architecture. In
 **OAuth with SSRAA Option:**
 
 Organizations already using OAuth with UDAP (via the [HL7 SSRAA IG](http://hl7.org/fhir/us/udap-security/)) can leverage VHL for health record sharing without additional authentication infrastructure. TEFCA participants, for example, can use their existing TEFCA-issued X.509 certificates and UDAP Dynamic Client Registration to authenticate VHL exchanges, enabling seamless interoperability within established national-scale health information networks.
+
+**Verifiable Credential Option:**
+
+TEFCA participants that have registered DID Documents in the trust network can alternatively use the Verifiable Credential Option for ITI-YY5 Retrieve Manifest authentication. A VHL Receiver acting within TEFCA self-issues a JWT-encoded Verifiable Credential (`application/vc+jwt`) using its registered DID, and presents it to the VHL Sharer via `Authorization: JWT-VC <token>`. This eliminates the need for a separate OAuth authorization server, making it well-suited for direct peer-to-peer exchanges between QHINs and participants who are already enrolled in a DID-based trust network.
 """

--- a/input/images-source/ITI-YY5.plantuml
+++ b/input/images-source/ITI-YY5.plantuml
@@ -7,18 +7,23 @@ participant "VHL Sharer" as Sharer
 
 Receiver -> Sharer: Retrieve Manifest Request [ITI-YY5]
 note right
-  POST signed request with:
-  - VHL token
-  - Search parameters
-  - Passcode (if required)
-  Over ATNA secure channel (optional)
+  POST /List/_search with:
+  - VHL search parameters (_id, code, status, patient.identifier)
+  - SHL parameters (recipient, passcode if P flag)
+  - Authentication (one of):
+    Option A: HTTP Message Signatures (RFC 9421)
+              Content-Digest + Signature-Input + Signature headers
+    Option B: OAuth with SSRAA — Authorization: Bearer <token>
+    Option C: Verifiable Credential — Authorization: JWT-VC <vc-jwt>
+  Over ATNA secure channel
 end note
 
 Sharer --> Receiver: Retrieve Manifest Response
 note left
   FHIR Bundle (searchset)
-  with DocumentReference
-  resources
+  - List resource (search.mode=match)
+  - DocumentReference resources (search.mode=include)
+    if Include DocumentReference Option supported
 end note
 
 @enduml

--- a/input/pagecontent/ITI-YY3.md
+++ b/input/pagecontent/ITI-YY3.md
@@ -288,3 +288,11 @@ When the {{ linkvhls }} supports the OAuth with SSRAA Option, it SHALL include `
 - The `fhirBaseUrl` value is typically derivable from the `url` field (manifest URL) by stripping the path, but including it explicitly avoids ambiguity when the authorization server is hosted separately
 - The {{ linkvhlr }} SHOULD cache its UDAP registration per `fhirBaseUrl` to avoid re-registering on every VHL scan
 - The `fhirBaseUrl` field MUST NOT be present if the {{ linkvhls }} does not support the OAuth with SSRAA Option, to avoid misleading {{ linkvhlr }}s into attempting UDAP Discovery unnecessarily
+
+#### 2:3.YY3.5.6 Verifiable Credential Option — FHIR Base URL Extension
+When the {{ linkvhls }} supports the Verifiable Credential Option, it SHALL include `extension.fhirBaseUrl` in the SHL payload (the same `fhirBaseUrl` extension used by the OAuth with SSRAA Option):
+- The `fhirBaseUrl` value MUST be the canonical FHIR base URL of the {{ linkvhls }} (e.g., `https://vhl-sharer.example.org`)
+- This value is used by the {{ linkvhlr }} as the `aud` claim in the VC JWT, scoping the credential to this specific {{ linkvhls }}
+- This value is also used by the {{ linkvhls }} to validate that the `aud` claim in incoming VC JWTs matches its own identity
+- The `fhirBaseUrl` value is typically derivable from the `url` field (manifest URL) by stripping the path, but including it explicitly avoids ambiguity
+- If both the OAuth with SSRAA Option and the Verifiable Credential Option are supported, a single `fhirBaseUrl` value serves both purposes

--- a/input/pagecontent/ITI-YY5.md
+++ b/input/pagecontent/ITI-YY5.md
@@ -16,9 +16,11 @@ This transaction occurs after the {{ linkvhlr }} has received a VHL from a VHL H
 
 **FHIR Search Transaction:** This transaction uses a standard FHIR search on the List resource, following the same pattern as MHD ITI-66 Find Document Lists. The manifest URL from the VHL payload contains all necessary FHIR search parameters. No custom operation is required.
 
-**Authentication:** Implementations SHALL support at least one of the following authentication mechanisms. Participants MAY use **HTTP Message Signatures (RFC 9421)** or **OAuth with SSRAA** depending on their deployment context. The VHL Sharer authenticates the requesting VHL Receiver before processing the request.
+**Authentication:** Implementations SHALL support at least one of the following authentication mechanisms. Participants MAY use **HTTP Message Signatures (RFC 9421)**, **OAuth with SSRAA**, or **Verifiable Credential (VC)** depending on their deployment context. The VHL Sharer authenticates the requesting VHL Receiver before processing the request. Any one of the three mechanisms is sufficient; both parties need not support all three.
 
 **OAuth with SSRAA Option:** Implementations MAY support the **OAuth with SSRAA Option**, which uses OAuth 2.0 tokens for authentication as defined in the [HL7 Security for Scalable Registration, Authentication, and Authorization IG](http://hl7.org/fhir/us/udap-security/) (SSRAA). When this option is supported, implementations use OAuth Backend Services with JWT client assertions for system-to-system authentication.
+
+**Verifiable Credential Option:** Implementations MAY support the **Verifiable Credential Option**, in which the VHL Receiver self-issues a JWT-encoded VC (W3C VC Data Model 2.0, `application/vc+jwt` encoding) signed with its private key and presents it to the VHL Sharer as `Authorization: JWT-VC <token>`. The VHL Sharer verifies the VC against the receiver's DID registered in the trust network.
 
 **Include DocumentReference Option:** A {{ linkvhls }} that supports the **Include DocumentReference Option** SHALL process the `_include=List:item` parameter to retrieve both the List and the referenced DocumentReference resources in a single response. This optimization reduces the number of round trips required by the {{ linkvhlr }}. If a {{ linkvhls }} does not support this option, it SHALL ignore the `_include` parameter, and the {{ linkvhlr }} SHALL retrieve each DocumentReference individually using separate read requests.
 
@@ -63,6 +65,12 @@ Both the {{ linkvhlr }} and {{ linkvhls }} SHALL authenticate each other's parti
 - **SMART App Launch Backend Services**: [Backend Services](http://hl7.org/fhir/smart-app-launch/backend-services.html)
 - **HL7 Security for Scalable Registration, Authentication, and Authorization IG**: [SSRAA](http://hl7.org/fhir/us/udap-security/)
 - **ITI Internet User Authorization (IUA)**: [IUA Profile](https://profiles.ihe.net/ITI/IUA/)
+
+**Verifiable Credential Option (Optional):**
+- **W3C Verifiable Credentials Data Model 2.0**: [VC Data Model](https://www.w3.org/TR/vc-data-model-2.0/)
+- **W3C Decentralized Identifiers (DIDs) Core 1.0**: [DID Core](https://www.w3.org/TR/did-core/)
+- **RFC 7519**: JSON Web Token (JWT) - reused for `application/vc+jwt` encoding
+- **IANA Media Type `application/vc+jwt`**: JWT-encoded Verifiable Credential
 
 **SHL Specifications:**
 - **SHL Manifest Request**: [SHL Manifest Request](http://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html#smart-health-link-manifest-request)
@@ -313,7 +321,101 @@ _id=abc123def456&code=folder&status=current&patient.identifier=urn%3Aoid%3A2.16.
 - Token lifetime SHOULD be limited (recommended: 1 hour maximum)
 - Authorization server MUST validate the JWT signature and the associated certificate validity, including that the certificate chains to a trust anchor in the trust community
 
-##### 2:3.YY5.4.1.5 Expected Actions - VHL Receiver
+##### 2:3.YY5.4.1.5 Authentication Option - Verifiable Credential Option
+
+Implementations that support the **Verifiable Credential Option** MAY use a self-issued JWT-encoded Verifiable Credential for authentication instead of HTTP Message Signatures or OAuth with SSRAA. The VHL Receiver acts as both issuer and subject of the VC, leveraging the DID it has registered in the trust network (via ITI-YY1).
+
+**Preconditions: Trust Network Enrollment**
+
+Before using this option, the {{ linkvhlr }} MUST have:
+- Registered its public key material and DID with the Trust Anchor (ITI-YY1 Submit PKI Material with DID)
+- Retrieved the {{ linkvhls }}'s DID or FHIR Base URL from the VHL payload (see ITI-YY3 Section 2:3.YY3.5.6 for the FHIR Base URL extension)
+
+The {{ linkvhls }} MUST have:
+- Retrieved the trust list from the Trust Anchor (ITI-YY2 Retrieve Trust List with DID) to obtain receiver DID-to-public-key mappings
+
+**VC JWT Structure**
+
+The VC is encoded as a compact JWT (`application/vc+jwt`) with the following structure:
+
+```
+Header:
+{
+  "alg": "ES256",
+  "typ": "JWT",
+  "kid": "<receiver-key-id>"
+}
+
+Payload:
+{
+  "iss": "did:web:vhl-receiver.example.org",
+  "sub": "did:web:vhl-receiver.example.org",
+  "aud": "https://vhl-sharer.example.org",
+  "iat": 1735689600,
+  "exp": 1735689900,
+  "jti": "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "vc": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2"
+    ],
+    "type": ["VerifiableCredential", "VHLReceiverIdentityCredential"],
+    "credentialSubject": {
+      "id": "did:web:vhl-receiver.example.org",
+      "type": "VHLReceiver"
+    }
+  }
+}
+```
+
+**JWT Field Requirements:**
+- `iss`: The receiver's DID as registered in the trust network (same as `sub` — self-issued)
+- `sub`: The receiver's DID (same as `iss`)
+- `aud`: The VHL Sharer's FHIR Base URL (from VHL payload extension, see ITI-YY3 Section 2:3.YY3.5.6) or DID
+- `iat`: Issued-at time (Unix epoch seconds)
+- `exp`: Expiry time — MUST be ≤5 minutes from `iat` (short-lived credential)
+- `jti`: Unique identifier for this VC (used to prevent replay attacks)
+- `vc.credentialSubject.id`: Receiver's DID (same as `iss`/`sub`)
+- Signature: signed with receiver's private key corresponding to the `kid` in the trust list
+
+**HTTP Request Example:**
+
+```http
+POST /List/_search HTTP/1.1
+Host: vhl-sharer.example.org
+Authorization: JWT-VC eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlY2VpdmVyLWtleS0xIn0.eyJpc3MiOiJkaWQ6d2ViOnZobC1yZWNlaXZlci5leGFtcGxlLm9yZyIsInN1YiI6ImRpZDp3ZWI6dmhsLXJlY2VpdmVyLmV4YW1wbGUub3JnIiwiYXVkIjoiaHR0cHM6Ly92aGwtc2hhcmVyLmV4YW1wbGUub3JnIiwiaWF0IjoxNzM1Njg5NjAwLCJleHAiOjE3MzU2ODk5MDAsImp0aSI6InVybjp1dWlkOmExYjJjM2Q0LWU1ZjYtNzg5MC1hYmNkLWVmMTIzNDU2Nzg5MCIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVkhMUmVjZWl2ZXJJZGVudGl0eUNyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6d2ViOnZobC1yZWNlaXZlci5leGFtcGxlLm9yZyIsInR5cGUiOiJWSExSZWNlaXZlciJ9fX0.signature-here
+Content-Type: application/x-www-form-urlencoded
+Accept: application/fhir+json
+
+_id=abc123def456&code=folder&status=current&patient.identifier=urn%3Aoid%3A2.16.840.1.113883.2.4.6.3%7CPASSPORT123&_include=List%3Aitem&recipient=Dr.+Smith+Hospital&passcode=user-pin&embeddedLengthMax=10000
+```
+
+**VC Authentication Process:**
+
+1. {{ linkvhlr }} constructs the JWT header and payload with its DID as `iss`/`sub` and the VHL Sharer's base URL as `aud`
+2. {{ linkvhlr }} signs the JWT with its private key (ES256 or RS256) associated with the `kid` registered in the trust network
+3. {{ linkvhlr }} includes the JWT in the `Authorization: JWT-VC <token>` header of the manifest request
+4. {{ linkvhls }} extracts the JWT from the `Authorization` header
+5. {{ linkvhls }} decodes the JWT header to obtain `kid`, and the payload to obtain `iss` (receiver's DID)
+6. {{ linkvhls }} retrieves the receiver's public key from the trust list using the `iss` DID (ITI-YY2)
+7. {{ linkvhls }} verifies the JWT signature using the retrieved public key
+8. {{ linkvhls }} verifies `exp` is in the future, `aud` matches its own identity, and `jti` has not been seen before
+
+**VC Requirements:**
+
+- Algorithm: ES256 (ECDSA P-256 SHA-256) or RS256 (RSA 2048+ with PKCS#1 v1.5) — ES256 recommended
+- Token Lifetime: `exp` MUST be ≤5 minutes from `iat`
+- Token Reuse: VC MUST NOT be reused; a new VC SHALL be generated for each manifest request
+- The `jti` claim MUST be unique per VC and SHALL be checked by the {{ linkvhls }} to prevent replay attacks
+
+**Security Considerations for Verifiable Credential:**
+
+- JWTs MUST be signed with the receiver's private key registered in the trust network
+- `exp` MUST be short-lived (≤5 minutes) to minimize replay window
+- `jti` replay cache SHOULD cover at least the maximum `exp` window
+- The `aud` claim MUST match the VHL Sharer's base URL or DID; mismatches SHALL be rejected (401 Unauthorized)
+- Private keys MUST be stored securely (Hardware Security Module recommended)
+
+##### 2:3.YY5.4.1.6 Expected Actions - VHL Receiver
 
 The {{ linkvhlr }} SHALL:
 
@@ -330,7 +432,7 @@ The {{ linkvhlr }} SHALL:
      - embeddedLengthMax (optional) - size hint for embedded content
    - Encode parameters as `application/x-www-form-urlencoded`
 
-3. **Authenticate Request** (use one of the following options; neither is required):
+3. **Authenticate Request** (use one of the following options; at least one SHALL be used):
    - **Option A - HTTP Message Signatures** (if supported):
      - Compute Content-Digest (SHA-256 of request body)
      - Construct signature base from HTTP components
@@ -340,6 +442,12 @@ The {{ linkvhlr }} SHALL:
      - Obtain access token using JWT client assertion
      - Include token in Authorization header
      - Reuse token for subsequent requests until expiration
+   - **Option C - Verifiable Credential** (if supported):
+     - Construct JWT payload with `iss`/`sub` = receiver's DID, `aud` = VHL Sharer base URL, `exp` ≤5 minutes from `iat`, unique `jti`
+     - Include `vc` claim with `VHLReceiverIdentityCredential` type
+     - Sign JWT with receiver's private key (ES256 recommended)
+     - Include JWT in `Authorization: JWT-VC <token>` header
+     - Generate a new VC for each request (MUST NOT reuse)
 
 4. **Send Request**:
    - POST to `/List/_search` endpoint at VHL Sharer's base URL
@@ -359,16 +467,17 @@ The {{ linkvhlr }} SHALL:
 The {{ linkvhlr }} MAY:
 - Cache OAuth access tokens for reuse (OAuth with SSRAA Option)
 - Implement retry logic for transient failures
-- Support both HTTP Message Signatures and OAuth with SSRAA Option
+- Support more than one of the three authentication options
+- Pre-generate a VC JWT immediately before each request (Verifiable Credential Option)
 
-##### 2:3.YY5.4.1.6 Expected Actions - VHL Sharer
+##### 2:3.YY5.4.1.7 Expected Actions - VHL Sharer
 
 Upon receiving Retrieve Manifest Request, the {{ linkvhls }} SHALL:
 
 1. **Parse Request**:
    - Extract FHIR search parameters from request body
    - Extract SHL parameters (recipient, passcode, embeddedLengthMax)
-   - Identify authentication method used (HTTP signatures or OAuth token)
+   - Identify authentication method used (HTTP Message Signatures, OAuth token, or Verifiable Credential JWT)
 
 2. **Authenticate Receiver**:
    - **HTTP Message Signatures**:
@@ -385,6 +494,15 @@ Upon receiving Retrieve Manifest Request, the {{ linkvhls }} SHALL:
      - Verify token expiration
      - Verify token scope authorizes access to the VHL
      - Reject if token invalid or expired (401 Unauthorized)
+   - **Verifiable Credential Option**:
+     - Extract JWT from `Authorization: JWT-VC` header
+     - Decode JWT header to obtain `kid`; decode payload to obtain `iss` (receiver's DID)
+     - Retrieve receiver's public key from trust list using the `iss` DID (ITI-YY2)
+     - Verify JWT signature using the retrieved public key
+     - Verify `exp` is in the future (not expired)
+     - Verify `aud` matches this VHL Sharer's FHIR Base URL or DID
+     - Verify `jti` has not been previously used (replay prevention)
+     - Reject if any check fails (401 Unauthorized)
 
 3. **Authorize Request**:
    - Validate folder ID (_id parameter) corresponds to valid VHL
@@ -661,7 +779,18 @@ All implementations SHALL support HTTP Message Signatures per RFC 9421:
 - Timestamp validation MUST enforce freshness (±2 minutes recommended)
 - Replay attacks prevented by timestamp validation
 
-#### 2:3.YY5.5.3 OAuth with SSRAA Option 
+#### 2:3.YY5.5.3 Verifiable Credential Option
+Implementations that support the Verifiable Credential Option SHALL:
+- Use ES256 (ECDSA P-256 SHA-256) or RS256 (RSA 2048+) for JWT signing; ES256 is recommended
+- Set `exp` to ≤5 minutes from `iat` (short-lived credential to minimize replay window)
+- Include a unique `jti` claim in every VC JWT to prevent replay attacks
+- Store private keys securely (Hardware Security Module recommended)
+- Resolve the receiver's public key from the trust list using the `iss` DID (ITI-YY2) before verifying
+- Maintain a `jti` replay cache covering at least the maximum `exp` window
+- Reject VC JWTs where `aud` does not match the VHL Sharer's FHIR Base URL or DID (401 Unauthorized)
+- Never reuse a VC JWT; a new JWT SHALL be generated for each manifest request
+
+#### 2:3.YY5.5.4 OAuth with SSRAA Option
 Implementations that support OAuth with SSRAA Option SHALL:
 - Use OAuth 2.0 Backend Services (client_credentials grant)
 - Use JWT client assertions (private_key_jwt) for client authentication
@@ -671,7 +800,7 @@ Implementations that support OAuth with SSRAA Option SHALL:
 - Check JWT `jti` claim to prevent replay attacks
 - Obtain receiver's public key from trust list for JWT signature validation
 
-#### 2:3.YY5.5.4 VHL Authorization
+#### 2:3.YY5.5.5 VHL Authorization
 {{ linkvhls }} MUST validate VHL before returning documents:
 - Verify folder ID (_id parameter) corresponds to valid VHL
 - Validate VHL signature (HCERT/CWT COSE signature from ITI-YY3)
@@ -682,33 +811,33 @@ Implementations that support OAuth with SSRAA Option SHALL:
   - Use strong hash function (bcrypt, Argon2, PBKDF2)
 - Confirm VHL scope authorizes requested documents
 
-#### 2:3.YY5.5.5 Trust Network Validation
+#### 2:3.YY5.5.6 Trust Network Validation
 Both {{ linkvhlr }} and {{ linkvhls }} SHALL:
 - Authenticate each other's participation in trust network
 - Obtain public keys from trust list (ITI-YY2 Retrieve Trust List with DID)
 - Validate certificates are not expired or revoked
-- Use `keyid` (HTTP signatures) or the client key (OAuth JWT) to identify the client's key
+- Use `keyid` (HTTP Message Signatures), the client key (OAuth JWT), or the `iss` DID (Verifiable Credential) to identify the client's key
 - Reject requests from participants not in trust list (401 Unauthorized)
 
-#### 2:3.YY5.5.6 Audit Logging
+#### 2:3.YY5.5.7 Audit Logging
 Both {{ linkvhlr }} and {{ linkvhls }} SHOULD log:
 - All document access requests (successful and failed)
-- Authentication method used (HTTP signatures or OAuth)
-- Receiver identity (from keyid or OAuth token)
+- Authentication method used (HTTP Message Signatures, OAuth with SSRAA, or Verifiable Credential)
+- Receiver identity (from `keyid`, OAuth token `sub`, or VC `iss` DID)
 - VHL folder ID
 - Authorization decisions (approved/denied)
 - Timestamps
 - IP addresses
 - User identifiers (from recipient parameter)
 
-#### 2:3.YY5.5.7 Rate Limiting
+#### 2:3.YY5.5.8 Rate Limiting
 {{ linkvhls }} SHOULD implement rate limiting:
-- Per receiver (identified by keyid or OAuth client_id)
+- Per receiver (identified by `keyid`, OAuth `client_id`, or VC `iss` DID)
 - Per folder ID (to prevent brute force on VHL tokens)
 - Per IP address
 - Return 429 Too Many Requests when limits exceeded
 
-#### 2:3.YY5.5.8 Passcode Security
+#### 2:3.YY5.5.9 Passcode Security
 When VHL is passcode-protected (P flag):
 - Passcode MUST be validated using constant-time comparison
 - Failed passcode attempts SHOULD be rate limited

--- a/input/pagecontent/issues.md
+++ b/input/pagecontent/issues.md
@@ -16,11 +16,13 @@
 
 - ToDo_004: Some of the language has the QR code as synonymous with the VHL.  Should be careful in Vol 1 that QR is only an example of a type of a VHL that is used for low-bandwidth/contactless/access.  May be other access mechanisms - bluetooth or NFC modalities are used in the future for the providing of a VHL by a VHL Holder to a VHL Receiver.   
 
-- ToDo_006: ITI-YY5 Receiver Authentication for Sharer using Embedded JWS/VC as an option
 
 - ToDo_007: ITI-YY5 Retrieve Manifest Message Semantics alignment with SHL — The current message semantics in ITI-YY5 (Section 2:3.YY5.4.1.2) may diverge from the SMART Health Links retrieve manifest specification. Liaise with the SHL team to identify gaps and request updates to the [SHL Manifest logical model](http://hl7.org/fhir/uv/smart-health-cards-and-links/STU1/links-specification.html#smart-health-link-manifest-file)
 
 ### Closed Issues
+
+- ToDo_006: ITI-YY5 Receiver Authentication for Sharer using Embedded JWS/VC as an option
+  - **Resolution:** Added the Verifiable Credential Option to ITI-YY5 (Section 2:3.YY5.4.1.5) and volume-1.md (Section XX.2.5). The VHL Receiver self-issues a JWT-encoded VC (`application/vc+jwt`) and presents it to the VHL Sharer via `Authorization: JWT-VC <token>`. ITI-YY3 updated to add Section 2:3.YY3.5.6 explaining that the `fhirBaseUrl` extension also serves the VC `aud` claim.
 
 - ToDo_002: Can we use the same transaction to retrieve a single doc VHL as well as retrieve the docs in a folder VHL?
   - **Resolution:** The specification defines a _include option in the ITI-YY5 transaction that supports both single document and folder-based VHL retrieval using the same transaction.

--- a/input/pagecontent/testplan.md
+++ b/input/pagecontent/testplan.md
@@ -33,15 +33,16 @@ The VHL Receiver must be tested for its ability to correctly perform the full VH
 
 #### Manifest Retrieval
 
-The VHL Receiver and VHL Sharer must be tested for the Retrieve Manifest transaction [ITI-YY5]. This includes the VHL Receiver's ability to construct and send a valid FHIR search request on the List resource with appropriate search parameters (_id, code, status, patient.identifier, _include) and SHL parameters (recipient, passcode). The VHL Sharer must be tested for returning a conformant searchset Bundle. Authentication via HTTP Message Signatures (RFC 9421) is required and must be validated.
+The VHL Receiver and VHL Sharer must be tested for the Retrieve Manifest transaction [ITI-YY5]. This includes the VHL Receiver's ability to construct and send a valid FHIR search request on the List resource with appropriate search parameters (_id, code, status, patient.identifier, _include) and SHL parameters (recipient, passcode). The VHL Sharer must be tested for returning a conformant searchset Bundle. Authentication is required and must be validated for all supported options: any one of HTTP Message Signatures (RFC 9421), OAuth with SSRAA, or Verifiable Credential may be used.
 
 #### Options Testing
 
 Testing of actor options includes:
-- **Sign Manifest Request Option** - VHL Receiver digitally signs manifest requests; VHL Sharer verifies the signature for mutual authentication and non-repudiation.
+- **Sign Manifest Request Option** - VHL Receiver digitally signs manifest requests using HTTP Message Signatures (RFC 9421); VHL Sharer verifies the signature for mutual authentication and non-repudiation.
 - **Include DocumentReference Option** - VHL Receiver requests and VHL Sharer returns DocumentReference resources in the manifest response using `_include=List:item`.
 - **Verify Document Signature Option** - VHL Receiver verifies digital signatures on retrieved documents using previously obtained PKI material.
-- **OAuth with FAST Option** - VHL Receiver and VHL Sharer use OAuth 2.0 access tokens as an alternative authentication mechanism for ITI-YY5.
+- **OAuth with SSRAA Option** - VHL Receiver and VHL Sharer use OAuth 2.0 access tokens (via UDAP/SSRAA) as an alternative authentication mechanism for ITI-YY5.
+- **Verifiable Credential Option** - VHL Receiver self-issues a JWT-encoded Verifiable Credential (`application/vc+jwt`) and presents it to the VHL Sharer via `Authorization: JWT-VC <token>` as a third alternative authentication mechanism for ITI-YY5.
 
 
 

--- a/input/pagecontent/volume-1.md
+++ b/input/pagecontent/volume-1.md
@@ -243,9 +243,11 @@ Options that may be selected for each actor in this implementation guide are lis
 | ^              | Include DocumentReference            |
 | ^              | Verify Document Signature            |
 | ^              | OAuth with SSRAA                     |
+| ^              | Verifiable Credential                |
 | {{ linkvhls }} | Include DocumentReference            |
 | ^              | Sign Manifest Request                |
 | ^              | OAuth with SSRAA                     |
+| ^              | Verifiable Credential                |
 {: .grid}
 
 
@@ -293,6 +295,21 @@ The OAuth with SSRAA Option enables the {{ linkvhlr }} and {{ linkvhls }} to use
 **Complementary Option:** Both the {{ linkvhlr }} and {{ linkvhls }} must support this option for OAuth-based authentication to be used. If only one actor supports this option, HTTP Message Signatures or other authentication mechanisms defined in ITI-YY5 SHALL be used instead.
 
 See ITI-YY5 Section 2:3.YY5.4.1.4 for detailed OAuth flow and examples.
+
+### XX.2.5 Verifiable Credential Option
+
+The Verifiable Credential Option enables the {{ linkvhlr }} and {{ linkvhls }} to use JWT-encoded Verifiable Credentials (W3C VC Data Model 2.0, `application/vc+jwt` encoding) for authentication during the ITI-YY5 Retrieve Manifest transaction, as an alternative to HTTP Message Signatures or OAuth with SSRAA.
+
+The {{ linkvhlr }} self-issues a VC (acting as both issuer and subject, using the DID registered in the trust network via ITI-YY1), signs it as a compact JWT, and presents it to the {{ linkvhls }} in the `Authorization: JWT-VC <token>` header. The {{ linkvhls }} verifies the VC against the receiver's DID in the trust list (ITI-YY2).
+
+This option provides:
+- Mutual authentication grounded in the VHL trust network PKI
+- Interoperability with the W3C Verifiable Credentials and Decentralized Identifiers ecosystems
+- A self-sovereign identity pattern — no separate authorization server required
+
+**Complementary Option:** Both the {{ linkvhlr }} and {{ linkvhls }} must support this option for VC-based authentication to be used. If only one actor supports this option, HTTP Message Signatures or OAuth with SSRAA SHALL be used instead.
+
+See ITI-YY5 Section 2:3.YY5.4.1.5 for detailed VC format, JWT structure, and flow examples.
 
 <a name="required-groupings"> </a>
 

--- a/input/tests/features/ITI-YY3-generate-vhl-responder.feature
+++ b/input/tests/features/ITI-YY3-generate-vhl-responder.feature
@@ -88,9 +88,26 @@ Feature: ITI-YY3 Generate VHL – VHL Sharer Expected Actions
     When the SHL payload is constructed
     Then the "extension" object SHALL include "fhirBaseUrl" set to the canonical FHIR base URL of the VHL Sharer
 
+  # ─── Verifiable Credential Option ─────────────────────────────────────────
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer includes extension.fhirBaseUrl when Verifiable Credential Option is supported
+    Given the VHL Sharer supports the Verifiable Credential Option
+    When the SHL payload is constructed
+    Then the "extension" object SHALL include "fhirBaseUrl" set to the canonical FHIR base URL of the VHL Sharer
+    And the VHL Receiver SHALL use this value as the "aud" claim in the VC JWT
+
+  @responder-actions @SHALL
+  Scenario: A single fhirBaseUrl serves both OAuth with SSRAA and Verifiable Credential when both are supported
+    Given the VHL Sharer supports both the OAuth with SSRAA Option and the Verifiable Credential Option
+    When the SHL payload is constructed
+    Then only one "extension.fhirBaseUrl" field SHALL be present
+    And its value SHALL serve both the OAuth UDAP discovery base URL and the VC JWT "aud" claim
+
   @responder-actions @MUST
-  Scenario: VHL Sharer does not include extension.fhirBaseUrl when OAuth with SSRAA Option is not supported
+  Scenario: VHL Sharer does not include extension.fhirBaseUrl when neither OAuth with SSRAA nor Verifiable Credential is supported
     Given the VHL Sharer does NOT support the OAuth with SSRAA Option
+    And the VHL Sharer does NOT support the Verifiable Credential Option
     When the SHL payload is constructed
     Then the "extension.fhirBaseUrl" field MUST NOT be present
 

--- a/input/tests/features/ITI-YY5-retrieve-manifest-initiator.feature
+++ b/input/tests/features/ITI-YY5-retrieve-manifest-initiator.feature
@@ -1,7 +1,8 @@
 Feature: ITI-YY5 Retrieve Manifest – VHL Receiver Expected Actions
   As a VHL Receiver (Initiator) retrieving the document manifest,
   these scenarios verify the actions the VHL Receiver MUST take when constructing
-  the authenticated request, handling OAuth (SSRAA Option), and processing the response.
+  the authenticated request, handling OAuth with SSRAA Option, Verifiable Credential
+  Option, or HTTP Message Signatures, and processing the response.
   Message format is defined in ITI-YY5-retrieve-manifest-message.feature.
 
   Background:
@@ -104,7 +105,42 @@ Feature: ITI-YY5 Retrieve Manifest – VHL Receiver Expected Actions
     When subsequent Retrieve Manifest requests are needed within that lifetime
     Then the VHL Receiver MAY reuse the access token until its "exp" claim is reached
 
-  # ─── §2:3.YY5.5.5 Trust Network Validation ────────────────────────────────
+  # ─── Authentication: Verifiable Credential Option (Option C) ─────────────────
+
+  @initiator-actions @MAY
+  Scenario: VHL Receiver may authenticate using a self-issued Verifiable Credential JWT
+    Given both the VHL Receiver and VHL Sharer support the Verifiable Credential Option
+    When the VHL Receiver authenticates using the Verifiable Credential Option
+    Then the VHL Receiver SHALL construct a VC JWT with its DID as "iss" and "sub"
+    And SHALL sign the JWT with its private key registered in the trust network
+    And SHALL include the JWT in "Authorization: JWT-VC <vc-jwt>"
+
+  @initiator-actions @SHALL
+  Scenario: VC JWT aud claim is set to the VHL Sharer's FHIR base URL from the VHL payload
+    Given the SHL payload contains "extension.fhirBaseUrl" for the VHL Sharer
+    When the VHL Receiver constructs the VC JWT
+    Then the "aud" claim SHALL be set to the value of "extension.fhirBaseUrl"
+
+  @initiator-actions @SHALL
+  Scenario: VC JWT exp is set to at most five minutes from iat
+    Given the VHL Receiver is constructing a VC JWT
+    When the expiry is set
+    Then "exp" SHALL NOT exceed 5 minutes after "iat"
+
+  @initiator-actions @SHALL
+  Scenario: VHL Receiver generates a new VC JWT for each manifest request
+    Given the VHL Receiver supports the Verifiable Credential Option
+    When two consecutive Retrieve Manifest requests are sent
+    Then a distinct VC JWT with a unique "jti" SHALL be generated for each request
+    And the same VC JWT SHALL NOT be reused across requests
+
+  @initiator-actions @SHALL
+  Scenario: VC JWT jti claim is unique per credential
+    Given the VHL Receiver is constructing a VC JWT
+    When the "jti" claim is set
+    Then the value SHALL be a UUID or equivalent unique identifier not previously used
+
+  # ─── §2:3.YY5.5.6 Trust Network Validation ────────────────────────────────
 
   @security @SHALL
   Scenario: VHL Receiver authenticates the VHL Sharer's participation in the trust network

--- a/input/tests/features/ITI-YY5-retrieve-manifest-message.feature
+++ b/input/tests/features/ITI-YY5-retrieve-manifest-message.feature
@@ -1,9 +1,10 @@
 Feature: ITI-YY5 Retrieve Manifest – Message Semantics
   Defines the format of the ITI-YY5 request and response messages.
   The request is an HTTP POST to /List/_search with FHIR search parameters
-  and SHL parameters. Authentication is via HTTP Message Signatures (RFC 9421)
-  or OAuth with SSRAA Option. The response is a FHIR searchset Bundle.
-  Defined once here for both the VHL Receiver (initiator) and VHL Sharer (responder).
+  and SHL parameters. Authentication is via one of: HTTP Message Signatures (RFC 9421),
+  OAuth with SSRAA Option, or Verifiable Credential Option. The response is a FHIR
+  searchset Bundle. Defined once here for both the VHL Receiver (initiator) and
+  VHL Sharer (responder).
 
   Background:
     Given a Retrieve Manifest exchange between a VHL Receiver and a VHL Sharer
@@ -127,6 +128,70 @@ Feature: ITI-YY5 Retrieve Manifest – Message Semantics
     Given the VHL Receiver is authenticating using OAuth with SSRAA Option
     When the authorization header is set
     Then the request SHALL include "Authorization: Bearer <access-token>"
+
+  # ─── Request: Verifiable Credential Option Headers (when Option C is used) ──
+
+  @message-semantics @SHALL
+  Scenario: Request includes Authorization JWT-VC header when Verifiable Credential Option is used
+    Given the VHL Receiver is authenticating using the Verifiable Credential Option
+    When the authorization header is set
+    Then the request SHALL include "Authorization: JWT-VC <vc-jwt>"
+
+  @message-semantics @SHALL
+  Scenario: VC JWT header specifies alg and kid
+    Given the VHL Receiver is constructing a VC JWT for the Verifiable Credential Option
+    When the JWT header is assembled
+    Then the header SHALL include "alg" set to "ES256" or "RS256"
+    And the header SHALL include "kid" identifying the receiver's key in the trust list
+
+  @message-semantics @SHALL
+  Scenario: VC JWT payload includes iss equal to the receiver's DID
+    Given the VHL Receiver is constructing a VC JWT
+    When the payload is assembled
+    Then the "iss" claim SHALL be the receiver's DID as registered in the trust network
+
+  @message-semantics @SHALL
+  Scenario: VC JWT payload includes sub equal to iss (self-issued)
+    Given the VHL Receiver is constructing a VC JWT
+    When the payload is assembled
+    Then the "sub" claim SHALL equal the "iss" claim (self-issued credential)
+
+  @message-semantics @SHALL
+  Scenario: VC JWT payload includes aud set to the VHL Sharer's FHIR base URL
+    Given the SHL payload contains "extension.fhirBaseUrl" for the VHL Sharer
+    When the VC JWT payload is assembled
+    Then the "aud" claim SHALL be the VHL Sharer's FHIR base URL
+
+  @message-semantics @SHALL
+  Scenario: VC JWT exp is no more than five minutes from iat
+    Given the VHL Receiver is constructing a VC JWT
+    When the expiry claims are set
+    Then "exp" SHALL be set to at most 5 minutes after "iat"
+
+  @message-semantics @SHALL
+  Scenario: VC JWT includes a unique jti claim
+    Given the VHL Receiver is constructing a VC JWT
+    When the "jti" claim is set
+    Then the value SHALL be a unique identifier not reused across requests
+
+  @message-semantics @SHALL
+  Scenario: VC JWT payload includes the vc claim with VHLReceiverIdentityCredential type
+    Given the VHL Receiver is constructing a VC JWT
+    When the "vc" claim is assembled
+    Then it SHALL include "@context" with "https://www.w3.org/ns/credentials/v2"
+    And the "type" array SHALL include "VerifiableCredential" and "VHLReceiverIdentityCredential"
+    And "credentialSubject.id" SHALL equal the receiver's DID
+
+  @message-semantics @SHALL
+  Scenario Outline: VC JWT signing algorithm is one of the approved algorithms
+    Given the VHL Receiver is authenticating using the Verifiable Credential Option
+    When the VC JWT is signed with "<algorithm>"
+    Then the algorithm SHALL be accepted as valid for the Verifiable Credential Option
+
+    Examples:
+      | algorithm |
+      | ES256     |
+      | RS256     |
 
   # ─── Response: Success Structure ─────────────────────────────────────────────
 

--- a/input/tests/features/ITI-YY5-retrieve-manifest-responder.feature
+++ b/input/tests/features/ITI-YY5-retrieve-manifest-responder.feature
@@ -93,7 +93,53 @@ Feature: ITI-YY5 Retrieve Manifest – VHL Sharer Expected Actions
     When the "jti" claim is evaluated
     Then the authorization server SHOULD check the "jti" claim to prevent replay attacks
 
-  # ─── §2:3.YY5.5.5 Trust Network Validation ────────────────────────────────
+  # ─── Verifiable Credential Option Verification (Option C) ──────────────────
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer extracts JWT from Authorization JWT-VC header when VC Option is used
+    Given the request includes "Authorization: JWT-VC <vc-jwt>" and the Verifiable Credential Option is supported
+    When the VHL Sharer processes the authorization header
+    Then the VHL Sharer SHALL extract the JWT from the "Authorization: JWT-VC" header
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer retrieves the receiver's public key from the trust list using the iss DID
+    Given the VC JWT has been extracted and decoded
+    When the VHL Sharer looks up the key
+    Then the VHL Sharer SHALL retrieve the receiver's public key from the trust list using the "iss" DID (ITI-YY2)
+    And SHALL return HTTP 401 Unauthorized if no key matches the "iss" DID
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer verifies the VC JWT signature using the retrieved public key
+    Given the receiver's public key has been retrieved via the "iss" DID
+    When VC JWT signature verification is performed
+    Then the VHL Sharer SHALL verify the JWT signature using the receiver's public key
+    And SHALL return HTTP 401 Unauthorized if the signature is invalid
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer rejects a VC JWT whose exp claim has passed
+    Given the VC JWT "exp" claim has passed
+    When the VC JWT is validated
+    Then the VHL Sharer SHALL return HTTP 401 Unauthorized
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer rejects a VC JWT whose aud does not match its own identity
+    Given the VC JWT "aud" claim does not match the VHL Sharer's FHIR base URL or DID
+    When the VC JWT is validated
+    Then the VHL Sharer SHALL return HTTP 401 Unauthorized
+
+  @responder-actions @SHALL
+  Scenario: VHL Sharer rejects a replayed VC JWT whose jti has already been used
+    Given a VC JWT with "jti" equal to a previously accepted value is received
+    When the jti is checked against the replay cache
+    Then the VHL Sharer SHALL return HTTP 401 Unauthorized
+
+  @responder-actions @SHOULD
+  Scenario: VHL Sharer maintains a jti replay cache covering at least the maximum exp window
+    Given the Verifiable Credential Option is supported
+    When VC JWTs are received
+    Then the VHL Sharer SHOULD maintain a "jti" replay cache covering at least the maximum "exp" window
+
+  # ─── §2:3.YY5.5.6 Trust Network Validation ────────────────────────────────
 
   @security @SHALL
   Scenario: VHL Sharer authenticates the VHL Receiver's participation in the trust network
@@ -186,7 +232,7 @@ Feature: ITI-YY5 Retrieve Manifest – VHL Sharer Expected Actions
     When transport security is evaluated
     Then the implementation SHALL comply with the IHE ATNA Profile (ITI TF-1: Section 9) for transport security requirements
 
-  # ─── §2:3.YY5.5.7 Rate Limiting ───────────────────────────────────────────
+  # ─── §2:3.YY5.5.8 Rate Limiting ───────────────────────────────────────────
 
   @responder-actions @SHOULD
   Scenario: VHL Sharer implements rate limiting per receiver and per folder ID
@@ -201,15 +247,15 @@ Feature: ITI-YY5 Retrieve Manifest – VHL Sharer Expected Actions
     Then the VHL Sharer SHALL return HTTP 429 Too Many Requests
     And the response SHALL include a FHIR OperationOutcome with issue.code "throttled"
 
-  # ─── §2:3.YY5.5.6 Audit Logging ───────────────────────────────────────────
+  # ─── §2:3.YY5.5.7 Audit Logging ───────────────────────────────────────────
 
   @responder-actions @SHOULD
   Scenario: VHL Sharer logs all manifest access requests including failed ones
     Given a Retrieve Manifest request has been processed
     When the audit event is recorded
-    Then the VHL Sharer SHOULD log receiver identity, folder ID, authentication method, authorization decision, and timestamp
+    Then the VHL Sharer SHOULD log receiver identity, folder ID, authentication method (HTTP Message Signatures / OAuth with SSRAA / Verifiable Credential), authorization decision, and timestamp
 
-  # ─── §2:3.YY5.5.8 Passcode Security ───────────────────────────────────────
+  # ─── §2:3.YY5.5.9 Passcode Security ───────────────────────────────────────
 
   @security @SHOULD
   Scenario: VHL Sharer rate limits failed passcode attempts


### PR DESCRIPTION
- ITI-YY5: Added VC as a third authentication option alongside HTTP Message Signatures and OAuth with SSRAA. VHL Receiver self-issues a JWT-encoded VC (application/vc+jwt, W3C VC Data Model 2.0) and presents it to the VHL Sharer via Authorization: JWT-VC <token>. New section 2:3.YY5.4.1.5 covers JWT structure, 8-step flow, requirements, and security considerations. Expected Actions (now .4.1.6/.4.1.7) updated to include Option C. Security Considerations renumbered to add 2:3.YY5.5.3 for VC; audit logging and rate limiting updated to reference all three auth methods.
- volume-1.md: Added Verifiable Credential to Actor Options table (Table XX.2-1) for both VHL Receiver and VHL Sharer; added new section XX.2.5 describing the option.
- ITI-YY3.md: Added section 2:3.YY3.5.6 explaining that the existing fhirBaseUrl extension also serves as the aud claim for VC JWTs.
- issues.md: Closed ToDo_006.

<!-- 
Thanks for creating this pull request 

Please make sure that the pull request is limited to one Issue and keep it as small as possible. You can open multiple pull request instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] I have selected a committee co-chair to review the PR

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->